### PR TITLE
Run Once example to grab so security forks

### DIFF
--- a/custom/127.0.0.1/git_grab_sectools.cmdr
+++ b/custom/127.0.0.1/git_grab_sectools.cmdr
@@ -1,5 +1,5 @@
 #Script to grab some of my other Forks
-cd /opt/;git clone https://github.com/dreilly369/ptf
+cd /opt/;git clone https://github.com/dreilly369/Dshell
 # For some reason it doesn't like staying cd'd across lines :(
 cd /opt/;git clone https://github.com/dreilly369/fruit_picker 
 cd /opt/;git clone https://github.com/dreilly369/arachni


### PR DESCRIPTION
This example grabs a bunch of forks and installs the MITMf framework
